### PR TITLE
chore: update ios-client-sdk to >= 11.0 and swift-eventsource to ~> 3.3

### DIFF
--- a/cartfile
+++ b/cartfile
@@ -1,2 +1,2 @@
-github "launchdarkly/ios-client-sdk" >= 9.0
-github "LaunchDarkly/swift-eventsource" ~> 3.1
+github "launchdarkly/ios-client-sdk" >= 11.0
+github "LaunchDarkly/swift-eventsource" ~> 3.3

--- a/hello-tvos/AppDelegate.swift
+++ b/hello-tvos/AppDelegate.swift
@@ -27,6 +27,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let config = LDConfig(mobileKey: sdkKey, autoEnvAttributes: .enabled)
 
-        LDClient.start(config: config, context: context)
+        LDClient.start(config: config, context: context, startWaitSeconds: 10)
     }
 }


### PR DESCRIPTION
## Summary

Updates the LaunchDarkly iOS client SDK minimum version from `>= 9.0` to `>= 11.0` (latest stable: 11.2.0) and swift-eventsource from `~> 3.1` to `~> 3.3` (latest: 3.3.0).

Fixes deprecated API usage: `LDClient.start(config:context:)` → `LDClient.start(config:context:startWaitSeconds:)` with a 10-second timeout, as the no-timeout variant was deprecated in v9.7.0.

**Testing**: This is a tvOS/Carthage project requiring Xcode on macOS — could not be built/tested on the CI environment. The code changes are minimal and follow the SDK's documented migration path.

Link to Devin session: https://app.devin.ai/sessions/a0a8a3bb8b80464885e41fc939a3016b
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bumps and a documented SDK API migration in a demo app only; no auth or production service changes.
> 
> **Overview**
> Bumps **Carthage** dependencies: `ios-client-sdk` from `>= 9.0` to `>= 11.0` and `swift-eventsource` from `~> 3.1` to `~> 3.3`.
> 
> The tvOS demo’s **`LDClient.start`** call is updated to the non-deprecated overload with **`startWaitSeconds: 10`**, replacing the two-argument `start(config:context:)` API removed/deprecated in newer SDK versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9a59731b4d668d5f847e5b6a2c778e81282f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->